### PR TITLE
Added Discord++

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@
  - [18sg/uSHET](https://github.com/18sg/uSHET/blob/c09e0acafd86720efe42dc15c63e0cc228244c32/lib/cpp_magic.h) -- A Malloc-Free SHET Client Library for Microcontrollers (`lib/cpp_magic.h`).
  - [ScrimpyCat/CommonC](https://github.com/ScrimpyCat/CommonC/blob/30983aa36b2e4e17ade1d0ad60ba7b27ccf16bad/CommonC/Template.h) -- Common utilities for C (`CommonC/Template.h`).
  - [cher-nov/Gena](https://github.com/cher-nov/Gena) -- Generic pseudo-templated containers for C. Written entirely in C89 with design inspired by the C++ STL.
+ - [DiscordPP/discordpp](https://github.com/DiscordPP/discordpp) and [DiscordPP/plugin-native](https://github.com/DiscordPP/plugin-native) -- A modular Discord library and a module for it that use macros to define Discord API endpoints and objects.
 
 ## Articles
 


### PR DESCRIPTION
https://github.com/DiscordPP/plugin-endpoints will be https://github.com/DiscordPP/plugin-native so I just added it like that and quickly moved the repo back and forth so that there's a redirect.

Macros can be found here:
Discord++:
Endpoints defined : https://github.com/DiscordPP/discordpp/tree/master/discordpp/macros
Endpoints in use: https://github.com/DiscordPP/discordpp/blob/master/discordpp/botStruct.hh#L46-L182
Plugin Native:
Endpoints in use: https://github.com/DiscordPP/plugin-endpoints/tree/dev/native/discordpp/endpoints
Objects defined: https://github.com/DiscordPP/plugin-endpoints/tree/dev/native/discordpp/util
Objects in use: https://github.com/DiscordPP/plugin-endpoints/tree/dev/native/discordpp/objects